### PR TITLE
Add self-referencing node model

### DIFF
--- a/.github/workflows/code_formatters.yml
+++ b/.github/workflows/code_formatters.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -55,7 +55,7 @@ class Tool(Base):
 
 
 class Node(Base):
-    parent_id: Mapped[UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("node.id"), nullable=True)
+    parent_id: Mapped[UUID | None] = mapped_column(UUID, ForeignKey("node.id"), nullable=True)
     summary: Mapped[str] = mapped_column(String(50))
     domain: Mapped[str] = mapped_column(String(50))
     children: Mapped[List["Node"]] = relationship(

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -1,8 +1,7 @@
 from typing import List
 from uuid import uuid4
 
-from sqlalchemy import ForeignKey, String, inspect
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import UUID, ForeignKey, String, inspect
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -17,7 +16,7 @@ class Base(DeclarativeBase):
     def __tablename__(cls) -> str:
         return cls.__name__.lower()
 
-    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(UUID, primary_key=True, default=uuid4)
 
     def __repr__(self) -> str:
         columns = inspect(self).mapper.columns

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -51,3 +51,14 @@ class Client(Base):
 class Tool(Base):
     operator_id: Mapped[UUID] = mapped_column(ForeignKey("operator.id"))
     operator: Mapped[Operator] = relationship(back_populates="tools")
+
+
+class Node(Base):
+    """
+    Represents a node in a knowledge graph.
+    """
+
+    summary: Mapped[str]  # A summary of the node contents
+    assoc: Mapped[str]  # What domain knowledge the node summary is associated with
+    parents: Mapped[list["Node"]]  # The parent nodes of this node
+    children: Mapped[list["Node"]]  # The child nodes of this node

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -57,7 +57,9 @@ class Tool(Base):
 class Node(Base):
     parent_id: Mapped[UUID | None] = mapped_column(UUID, ForeignKey("node.id"), nullable=True)
     summary: Mapped[str] = mapped_column(String(50))
-    domain: Mapped[str] = mapped_column(String(50))
+    # TODO: Better solution for domain. ATM, it's going to look like repo/abop/concrete/[file_path]/[chunk].
+    # This solution is slow and not scalable.
+    domain: Mapped[str] = mapped_column(String(50))  # Refers to what the node is summarizing, like a file/dir/function
     children: Mapped[List["Node"]] = relationship(
         "Node", back_populates="parent", cascade="all, delete-orphan", primaryjoin="Node.id == foreign(Node.parent_id)"
     )

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -1,3 +1,4 @@
+from typing import Integer
 from uuid import UUID, uuid4
 
 from sqlalchemy import ForeignKey, String, inspect
@@ -53,12 +54,26 @@ class Tool(Base):
     operator: Mapped[Operator] = relationship(back_populates="tools")
 
 
-class Node(Base):
-    """
-    Represents a node in a knowledge graph.
-    """
+# class Node(Base):
+#     """
+#     Table for storing nodes in a knowledge graph.
+#     Each node can have one parent.
+#     """
 
-    summary: Mapped[str]  # A summary of the node contents
-    assoc: Mapped[str]  # What domain knowledge the node summary is associated with
-    parents: Mapped[list["Node"]]  # The parent nodes of this node
-    children: Mapped[list["Node"]]  # The child nodes of this node
+#     summary: Mapped[str] = mapped_column(String)  # A summary of the node contents
+#     assoc: Mapped[str] = mapped_column(String)  # What domain knowledge the node summary is associated with
+
+#     parent_id: Mapped[UUID | None] = mapped_column(ForeignKey("node.id"), nullable=True)
+#     parent: Mapped["Node" | None] = relationship("Node", back_populates="children", remote_side=[id])
+#     children: Mapped[list["Node"] | None] = relationship("Node", back_populates="parent")
+
+
+# https://docs.sqlalchemy.org/en/20/orm/self_referential.html
+class Node(Base):
+    summary: Mapped[str] = mapped_column(String)
+    assoc: Mapped[str] = mapped_column(String)
+
+    # Bidirectional relationship, one (parent) to many (children).
+    parent_id = mapped_column(Integer, ForeignKey("node.id"))
+    children = relationship("Node", back_populates="parent")
+    parent = relationship("Node", back_populates="children", remote_side=[id])

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -1,7 +1,8 @@
-from typing import Integer
-from uuid import UUID, uuid4
+from typing import List
+from uuid import uuid4
 
 from sqlalchemy import ForeignKey, String, inspect
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -16,7 +17,7 @@ class Base(DeclarativeBase):
     def __tablename__(cls) -> str:
         return cls.__name__.lower()
 
-    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
 
     def __repr__(self) -> str:
         columns = inspect(self).mapper.columns
@@ -54,26 +55,14 @@ class Tool(Base):
     operator: Mapped[Operator] = relationship(back_populates="tools")
 
 
-# class Node(Base):
-#     """
-#     Table for storing nodes in a knowledge graph.
-#     Each node can have one parent.
-#     """
-
-#     summary: Mapped[str] = mapped_column(String)  # A summary of the node contents
-#     assoc: Mapped[str] = mapped_column(String)  # What domain knowledge the node summary is associated with
-
-#     parent_id: Mapped[UUID | None] = mapped_column(ForeignKey("node.id"), nullable=True)
-#     parent: Mapped["Node" | None] = relationship("Node", back_populates="children", remote_side=[id])
-#     children: Mapped[list["Node"] | None] = relationship("Node", back_populates="parent")
-
-
-# https://docs.sqlalchemy.org/en/20/orm/self_referential.html
 class Node(Base):
-    summary: Mapped[str] = mapped_column(String)
-    assoc: Mapped[str] = mapped_column(String)
+    parent_id: Mapped[UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("node.id"), nullable=True)
+    summary: Mapped[str] = mapped_column(String(50))
+    domain: Mapped[str] = mapped_column(String(50))
+    children: Mapped[List["Node"]] = relationship(
+        "Node", back_populates="parent", cascade="all, delete-orphan", primaryjoin="Node.id == foreign(Node.parent_id)"
+    )
 
-    # Bidirectional relationship, one (parent) to many (children).
-    parent_id = mapped_column(Integer, ForeignKey("node.id"))
-    children = relationship("Node", back_populates="parent")
-    parent = relationship("Node", back_populates="children", remote_side=[id])
+    parent: Mapped["Node | None"] = relationship(
+        "Node", back_populates="children", primaryjoin="foreign(Node.parent_id) == remote(Node.id)"
+    )

--- a/concrete/db/orm/schemas.py
+++ b/concrete/db/orm/schemas.py
@@ -63,20 +63,11 @@ class NodeBase(ConcreteModel):
 
     summary: str = Field(description="Summary of the node.")
     domain: str = Field(description="Association of the node.")
-
-
-class NodeCreate(NodeBase):
     parent_id: UUID | None = Field(default=None, description="ID of the parent node.")  # root has no parent
 
 
-class Node(NodeBase, MetadataMixin, OrmMixin):
-    """
-    Full representation of a Node
-    """
-
-    id: UUID
-    parent_id: int | None = Field(default=None, description="ID of the parent node.")
-    children: list["Node"] | None = Field(default_factory=list, description="Child nodes of this node.")
+class NodeCreate(NodeBase):
+    pass
 
 
 class NodeUpdate(ConcreteModel):

--- a/concrete/db/orm/schemas.py
+++ b/concrete/db/orm/schemas.py
@@ -66,7 +66,7 @@ class NodeBase(ConcreteModel):
 
 
 class NodeCreate(NodeBase):
-    parent_id: int | None = Field(default=None, description="ID of the parent node.")  # root has no parent
+    parent_id: UUID | None = Field(default=None, description="ID of the parent node.")  # root has no parent
 
 
 class Node(NodeBase, MetadataMixin, OrmMixin):

--- a/concrete/db/orm/schemas.py
+++ b/concrete/db/orm/schemas.py
@@ -56,21 +56,31 @@ class Tool(ToolBase, MetadataMixin, OrmMixin, OperatorChildMixin):
     pass
 
 
-# Nodes for knowledge graph
 class NodeBase(ConcreteModel):
-    summary: str = Field(description="A summary of the associated domain knowledge")
-    assoc: str = Field(description="Domain knowledge the node summary is associated with")
-    parents: list["Node"] = Field(description="Parent nodes of this node", default=[])
-    children: list["Node"] = Field(description="Child nodes of this node", default=[])
+    """
+    Base model for a Node.
+    """
+
+    summary: str = Field(description="Summary of the node.")
+    assoc: str = Field(description="Association of the node.")
+
+
+class NodeCreate(NodeBase):
+    parent_id: int | None = Field(default=None, description="ID of the parent node.")  # root has no parent
 
 
 class Node(NodeBase, MetadataMixin, OrmMixin):
-    pass
+    """
+    Full representation of a Node
+    """
 
-
-class NodeCreate(Node):
-    pass
+    id: UUID
+    parent_id: int | None = Field(default=None, description="ID of the parent node.")
+    children: list["Node"] | None = Field(default_factory=list, description="Child nodes of this node.")
+    parent: "Node" | None = Field(default=None, description="Parent node of this node.")
 
 
 class NodeUpdate(ConcreteModel):
-    pass
+    summary: str | None = Field(default=None, description="Summary of the node.")
+    assoc: str | None = Field(default=None, description="Domain knowledge association of the node.")
+    parent_id: int | None = Field(default=None, description="ID of the parent node.")

--- a/concrete/db/orm/schemas.py
+++ b/concrete/db/orm/schemas.py
@@ -54,3 +54,23 @@ class ToolBase(ConcreteModel):
 
 class Tool(ToolBase, MetadataMixin, OrmMixin, OperatorChildMixin):
     pass
+
+
+# Nodes for knowledge graph
+class NodeBase(ConcreteModel):
+    summary: str = Field(description="A summary of the associated domain knowledge")
+    assoc: str = Field(description="Domain knowledge the node summary is associated with")
+    parents: list["Node"] = Field(description="Parent nodes of this node", default=[])
+    children: list["Node"] = Field(description="Child nodes of this node", default=[])
+
+
+class Node(NodeBase, MetadataMixin, OrmMixin):
+    pass
+
+
+class NodeCreate(Node):
+    pass
+
+
+class NodeUpdate(ConcreteModel):
+    pass

--- a/concrete/db/orm/schemas.py
+++ b/concrete/db/orm/schemas.py
@@ -62,7 +62,7 @@ class NodeBase(ConcreteModel):
     """
 
     summary: str = Field(description="Summary of the node.")
-    assoc: str = Field(description="Association of the node.")
+    domain: str = Field(description="Association of the node.")
 
 
 class NodeCreate(NodeBase):
@@ -77,10 +77,9 @@ class Node(NodeBase, MetadataMixin, OrmMixin):
     id: UUID
     parent_id: int | None = Field(default=None, description="ID of the parent node.")
     children: list["Node"] | None = Field(default_factory=list, description="Child nodes of this node.")
-    parent: "Node" | None = Field(default=None, description="Parent node of this node.")
 
 
 class NodeUpdate(ConcreteModel):
     summary: str | None = Field(default=None, description="Summary of the node.")
-    assoc: str | None = Field(default=None, description="Domain knowledge association of the node.")
+    domain: str | None = Field(default=None, description="Domain knowledge association of the node.")
     parent_id: int | None = Field(default=None, description="ID of the parent node.")

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -656,7 +656,7 @@ class KnowledgeGraphTool(metaclass=MetaTool):
     """
 
     @classmethod
-    def repo_to_knowledge(cls, org: str, repo: str, access_token: str) -> Node | None:
+    def repo_to_knowledge(cls, org: str, repo: str, access_token: str) -> Node:
         """
         Converts a repository into a knowledge graph.
 
@@ -666,4 +666,4 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         Returns
             Node: The root node of the knowledge graph
         """
-        return None
+        raise NotImplementedError("This tool is not yet implemented.")

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -647,3 +647,11 @@ class GithubTool(metaclass=MetaTool):
         diff = GithubTool.get_diff(org, repo, base, compare, access_token)
         files_with_diffs = diff.split('diff --git')[1:]  # Skip the first empty element
         return [(file.split('\n', 1)[0].split(), file) for file in files_with_diffs]
+
+
+class RepoToKnowledgeGraphTool(metaclass=MetaTool):
+    """
+    Converts a directory into a repository knowledge graph.
+    """
+
+    pass

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -66,6 +66,7 @@ import requests
 from requests import Response
 
 from .clients import CLIClient, HTTPClient
+from .db.orm.models import Node
 from .models.base import ConcreteModel
 from .models.messages import ProjectDirectory
 
@@ -649,9 +650,20 @@ class GithubTool(metaclass=MetaTool):
         return [(file.split('\n', 1)[0].split(), file) for file in files_with_diffs]
 
 
-class RepoToKnowledgeGraphTool(metaclass=MetaTool):
+class KnowledgeGraphTool(metaclass=MetaTool):
     """
-    Converts a directory into a repository knowledge graph.
+    Converts a repository into a knowledge graph.
     """
 
-    pass
+    @classmethod
+    def repo_to_knowledge(cls, org: str, repo: str, access_token: str) -> Node | None:
+        """
+        Converts a repository into a knowledge graph.
+
+        args
+            org (str): Organization or account owning the repo
+            repo (str): The name of the repository
+        Returns
+            Node: The root node of the knowledge graph
+        """
+        return None


### PR DESCRIPTION
- Add SQLAlchemy model for Nodes in a knowledge graph.
  - Nodes can have one parent, many children
  - Basically identical to an adjacency list, but through sqlalchemy. 
