### PR TITLE
Add Knowledge Graph functions to navigate to Documentation

### DIFF
--- a/concrete/db/crud.py
+++ b/concrete/db/crud.py
@@ -332,8 +332,8 @@ def get_root_repo_node(db: Session, org: str, repo: str) -> RepoNode | None:
     # Can't do is None in sqlalchemy. Use Comparators == !=
     # or https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
     stmt = select(RepoNode).where(
-        RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None)
-    )  # type: ignore
+        RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None)  # type: ignore
+    )
     return db.scalars(stmt).first()
 
 

--- a/concrete/db/crud.py
+++ b/concrete/db/crud.py
@@ -333,7 +333,7 @@ def get_root_repo_node(db: Session, org: str, repo: str) -> RepoNode | None:
     # or https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
     stmt = select(RepoNode).where(
         RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None)
-    )  # type: ignore # noqa
+    )  # type: ignore
     return db.scalars(stmt).first()
 
 

--- a/concrete/db/crud.py
+++ b/concrete/db/crud.py
@@ -326,3 +326,8 @@ def get_repo_node(db: Session, repo_node_id: UUID) -> RepoNode | None:
 
 def update_repo_node(db: Session, repo_node_id: UUID, repo_node_update: RepoNodeUpdate) -> RepoNode | None:
     return update_generic(db, get_repo_node(db, repo_node_id), repo_node_update)
+
+
+def get_root_repo_node(db: Session, org: str, repo: str) -> RepoNode | None:
+    stmt = select(RepoNode).where(RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id is None)
+    return db.scalars(stmt).first()

--- a/concrete/db/crud.py
+++ b/concrete/db/crud.py
@@ -329,5 +329,7 @@ def update_repo_node(db: Session, repo_node_id: UUID, repo_node_update: RepoNode
 
 
 def get_root_repo_node(db: Session, org: str, repo: str) -> RepoNode | None:
-    stmt = select(RepoNode).where(RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id is None)
+    # Can't do is None in sqlalchemy. Use Comparators == !=
+    # or https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
+    stmt = select(RepoNode).where(RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None))  # type: ignore # noqa
     return db.scalars(stmt).first()

--- a/concrete/db/crud.py
+++ b/concrete/db/crud.py
@@ -331,5 +331,12 @@ def update_repo_node(db: Session, repo_node_id: UUID, repo_node_update: RepoNode
 def get_root_repo_node(db: Session, org: str, repo: str) -> RepoNode | None:
     # Can't do is None in sqlalchemy. Use Comparators == !=
     # or https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
-    stmt = select(RepoNode).where(RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None))  # type: ignore # noqa
+    stmt = select(RepoNode).where(
+        RepoNode.org == org, RepoNode.repo == repo, RepoNode.parent_id.is_(None)
+    )  # type: ignore # noqa
+    return db.scalars(stmt).first()
+
+
+def get_repo_node_by_path(db: Session, org: str, repo: str, abs_path: str) -> RepoNode | None:
+    stmt = select(RepoNode).where(RepoNode.org == org, RepoNode.repo == repo, RepoNode.abs_path == abs_path)
     return db.scalars(stmt).first()

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -249,6 +249,7 @@ class RepoNodeBase(Base):
     partition_type: str = Field(description="Type of the node. directory/file/chunk")
     name: str = Field(description="Name of the chunk. eg README.md, module.py/func_foo")
     summary: str = Field(description="Summary of the node.")
+    children_summaries: list[str] = Field(description="Brief summary of each child node.")
     parent_id: UUID | None = Field(
         default=None,
         description="ID of the parent node.",
@@ -264,6 +265,7 @@ class RepoNodeUpdate(NodeUpdate):
     type: str | None = Field(description="Type of the node. directory/file/chunk", default=None)
     name: str | None = Field(description="Name of the chunk. eg README.md, module.py/func_foo", default=None)
     summary: str | None = Field(description="Summary of the node.", default=None)
+    children_summaries: list[str] | None = Field(description="Brief summary of each child node.", default=None)
     abs_path: str | None = Field(description="", default=None)
 
 

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -273,6 +273,9 @@ class RepoNodeCreate(RepoNodeBase):
     pass
 
 
+# Link on how to define composite indices in SQLModel.
+# SQLModel provides abstraction for single column indices, but it appears that the
+# correct way to do composite indices is to define them in db schema at the sqlalchemy level.
 # https://stackoverflow.com/questions/70958639/composite-indexes-sqlmodel
 class RepoNode(RepoNodeBase, MetadataMixin, table=True):
     children: list["RepoNode"] = Relationship(

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -249,7 +249,7 @@ class RepoNodeBase(Base):
     partition_type: str = Field(description="Type of the node. directory/file/chunk")
     name: str = Field(description="Name of the chunk. eg README.md, module.py/func_foo")
     summary: str = Field(description="Summary of the node.")
-    children_summaries: list[str] = Field(description="Brief summary of each child node.")
+    children_summaries: str = Field(description="Brief summary of each child node.")
     parent_id: UUID | None = Field(
         default=None,
         description="ID of the parent node.",
@@ -265,7 +265,7 @@ class RepoNodeUpdate(NodeUpdate):
     type: str | None = Field(description="Type of the node. directory/file/chunk", default=None)
     name: str | None = Field(description="Name of the chunk. eg README.md, module.py/func_foo", default=None)
     summary: str | None = Field(description="Summary of the node.", default=None)
-    children_summaries: list[str] | None = Field(description="Brief summary of each child node.", default=None)
+    children_summaries: str | None = Field(description="Brief summary of each child node.", default=None)
     abs_path: str | None = Field(description="", default=None)
 
 

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from uuid import UUID, uuid4
 
+from sqlalchemy.schema import Index
 from sqlmodel import Field, Relationship, SQLModel
 
 from ...state import ProjectStatus
@@ -270,6 +271,7 @@ class RepoNodeCreate(RepoNodeBase):
     pass
 
 
+# https://stackoverflow.com/questions/70958639/composite-indexes-sqlmodel
 class RepoNode(RepoNodeBase, MetadataMixin, table=True):
     children: list["RepoNode"] = Relationship(
         back_populates="parent",
@@ -279,6 +281,8 @@ class RepoNode(RepoNodeBase, MetadataMixin, table=True):
         back_populates="children",
         sa_relationship_kwargs={"remote_side": "reponode.c.id"},
     )
+
+    __table_args__ = (Index('ix_org_repo', 'org', 'repo'),)
 
 
 SQLModel.metadata.create_all(bind=engine)

--- a/concrete/models/messages.py
+++ b/concrete/models/messages.py
@@ -19,8 +19,6 @@ String, Number, Boolean, Integer, Object, Array, Enum, anyOf
 Optional is not allowed with OpenAI Structured Outputs. All fields must be required.
 """
 
-from uuid import UUID
-
 from pydantic import Field
 
 from .base import ConcreteModel, KombuMixin

--- a/concrete/models/messages.py
+++ b/concrete/models/messages.py
@@ -80,3 +80,14 @@ class Summary(Message, KombuMixin):
 
 class PlannedComponents(Message, KombuMixin):
     components: list[str] = Field(description="List of planned components")
+
+
+class ChildNodeSummary(Message, KombuMixin):
+    node_name: str = Field(description="Name of the node")
+    summary: str = Field(description="Summary of the node")
+
+
+class NodeSummary(Message, KombuMixin):
+    node_name: str = Field(description="Name of the node")
+    overall_summary: str = Field(description="Summary of the node")
+    children_summaries: list[ChildNodeSummary] = Field(description="Brief description of each child node")

--- a/concrete/models/messages.py
+++ b/concrete/models/messages.py
@@ -19,6 +19,8 @@ String, Number, Boolean, Integer, Object, Array, Enum, anyOf
 Optional is not allowed with OpenAI Structured Outputs. All fields must be required.
 """
 
+from uuid import UUID
+
 from pydantic import Field
 
 from .base import ConcreteModel, KombuMixin
@@ -91,3 +93,7 @@ class NodeSummary(Message, KombuMixin):
     node_name: str = Field(description="Name of the node")
     overall_summary: str = Field(description="Summary of the node")
     children_summaries: list[ChildNodeSummary] = Field(description="Brief description of each child node")
+
+
+class NodeUUID(Message, KombuMixin):
+    node_uuid: str = Field(description="UUID of the node")

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -264,7 +264,7 @@ Format your response as:
 
     def summarize_from_children(self, children_summaries: list[str], *args, **kwargs) -> str:
         joined_summaries = "\n\n".join(children_summaries)
-        return f"""Summarize the following by aggregating the following children. Deliver a high-level overview, ensuring that important children are emphasized. The summary should capture ALL children, and the main functionalities of the children as a whole.
+        return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality.
 Your returned summary should follow the format:
 <directory name> Summary: <overall summary of the directory>
 Children Summaries:

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -215,15 +215,18 @@ Current Component Implementation: {implementation}
 Previous Components: {summary}"""  # noqa E501
         return prompt
 
-    def update_parent_summary(self, parent_summary: str, child_summary: str, child_name: str, *args, **kwargs) -> str:
+    def update_parent_summary(
+        self, parent_summary: str, child_summary: str, parent_child_summaries: str, child_name: str, *args, **kwargs
+    ) -> str:
         """
         Updates the parent summary with the child summary
         Returns the updated parent summary
         """
         return f"""Given the following parent summary structure:
-Parent Summary: <{parent_summary}>
+Existing Parent Overall Summary: <{parent_summary}>
+Existing Parent Child Summaries: <{parent_child_summaries}>
 
-Your task is to update this summary with the new child summary:
+Your task is to update the existing summary with this new child summary:
 Child Name: <{child_name}>
 Child Summary: <{child_summary}>
 
@@ -232,10 +235,11 @@ Follow these steps:
 2. If the parent summary exists:
    a. Add the new child summary if it's not already present.
    b. If a summary for this child already exists, replace it with the new one.
-   c. Update the Overall Summary to reflect all children.
-3. Maintain this structure for the parent summary:
+3. Update the Overall Summary to reflect all child summaries.
 
-Overall Summary: <summary of all children>
+Maintain this structure for the returned summary:
+Parent Name: <parent_name>
+Parent Overall Summary: <summary of all children>
 
 Child Summaries:
    - Child Name: <child_name>
@@ -259,18 +263,21 @@ Name: {file_name}
 Contents: {contents}
 
 Format your response as:
-<Name> Summary: <summary of contents>
+node_name: <Name>
+summary: <summary of file contents>
 """  # noqa
 
-    def summarize_from_children(self, children_summaries: list[str], *args, **kwargs) -> str:
+    def summarize_from_children(self, children_summaries: list[str], parent_name: str, *args, **kwargs) -> str:
         joined_summaries = "\n\n".join(children_summaries)
         return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality.
+    
 Your returned summary should follow the format:
-<directory name> Summary: <overall summary of the directory>
-Children Summaries:
-    - Child Name: <child Name>
+Node Name: {parent_name}
+Overall Summary: <High-level summary of the directory>
+Children Summaries: 
+    - Child Name: <child name>
       Child Summary: <child summary>
-    - Child Name: <child Name>
+    - Child Name: <child name>
       Child Summary: <child summary>
 
 Here are the children summaries.

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -249,14 +249,13 @@ Child Summaries:
    ...
 
 Guidelines:
-- Ensure the Overall Summary provides a concise overview of all children.
+- Ensure the Overall Summary provides a high-level  overview of all children while preserving important implementation details.
 - Each child summary should accurately represent its corresponding node.
-
-Your response should be the updated parent summary in the specified format."""
+"""  # noqa
 
     def summarize_file(self, contents: str, file_name: str, *args, **kwargs) -> str:
         return f"""Provide a concise summary of the following file, focusing on its purpose and the key functionalities of its contents. 
-The summary should give a high-level overview that explains what the file is for and its primary components or actions.
+The summary should give a high-level overview that explains what the file is for and its primary components or actions. Keep critical implementation details in mind.
 Return the summary in one paragraph.
 Below are the file's name and contents:
 Name: {file_name}
@@ -269,7 +268,7 @@ summary: <summary of file contents>
 
     def summarize_from_children(self, children_summaries: list[str], parent_name: str, *args, **kwargs) -> str:
         joined_summaries = "\n\n".join(children_summaries)
-        return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality.
+        return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality. Keep critical implementation details in children summaries in mind.
     
 Your returned summary should follow the format:
 Node Name: {parent_name}

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -251,19 +251,20 @@ Guidelines:
 Your response should be the updated parent summary in the specified format."""
 
     def summarize_file(self, contents: str, file_name: str, *args, **kwargs) -> str:
-        return f"""Summarize the following contents. Be concise, and capture all functionalities.
+        return f"""Provide a concise summary of the following file, focusing on its purpose and the key functionalities of its contents. 
+The summary should give a high-level overview that explains what the file is for and its primary components or actions.
 Return the summary in one paragraph.
-Following is the contents and its name
+Below are the file's name and contents:
 Name: {file_name}
 Contents: {contents}
 
-Your summary should follow the format:
+Format your response as:
 <Name> Summary: <summary of contents>
-"""
+"""  # noqa
 
     def summarize_from_children(self, children_summaries: list[str], *args, **kwargs) -> str:
         joined_summaries = "\n\n".join(children_summaries)
-        return f"""Summarize the following directory. Be concise, and capture the main functionalities of the directory.
+        return f"""Summarize the following by aggregating the following children. Deliver a high-level overview, ensuring that important children are emphasized. The summary should capture ALL children, and the main functionalities of the children as a whole.
 Your returned summary should follow the format:
 <directory name> Summary: <overall summary of the directory>
 Children Summaries:
@@ -272,8 +273,8 @@ Children Summaries:
     - Child Name: <child Name>
       Child Summary: <child summary>
 
-Here are the children summaries. Children can be either files or directories. They have a similar summary format.
-{joined_summaries}"""
+Here are the children summaries.
+{joined_summaries}"""  # noqa
 
 
 class PromptEngineer(Operator):

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -473,33 +473,40 @@ class GithubTool(metaclass=MetaTool):
     }
 
     @classmethod
-    def make_pr(cls, owner: str, repo: str, branch: str, title: str = "PR", base: str = "main") -> dict:
+    def create_pr(
+        cls, org: str, repo: str, branch: str, access_token: str, title: str = "PR", base: str = "main"
+    ) -> dict:
         """
         Make a pull request on the target repo
 
         e.g. make_pr('abstractoperators', 'concrete', 'kent/http-tool')
 
         Args
-            owner (str): The organization or accounts that owns the repo.
+            org (str): The organization or accounts that owns the repo.
             repo (str): The name of the repository.
             branch (str): The head branch being merged into the base.
             title (str): The title of the PR being created.
             base (str): The title of the branch that changes are being merged into.
         """
-        url = f"https://api.github.com/repos/{owner}/{repo}/pulls"
+        url = f"https://api.github.com/repos/{org}/{repo}/pulls"
         json = {"title": f"[ABOP] {title}", "head": branch, "base": base}
-        return RestApiTool.post(url, headers=cls.headers, json=json)
+        headers = {
+            'Accept': 'application/vnd.github+json',
+            'Authorization': f'Bearer {access_token}',
+            'X-GitHub-Api-Version': '2022-11-28',
+        }
+        return RestApiTool.post(url, headers=headers, json=json)
 
     @classmethod
-    def make_branch(cls, org: str, repo: str, base_branch: str, new_branch: str, access_token: str):
+    def create_branch(cls, org: str, repo: str, new_branch: str, access_token: str, base_branch: str = 'main'):
         """
-        Make a branch called target_name from the latest commit on base_name
+        Make a branch called new_branch from the latest commit on base_name
 
         Args
             org (str): Organization or account owning the repo
             repo (str): The name of the repository
             base_branch (str): The name of the branch to branch from.
-            new_branch (str): The name of the new branch
+            new_branch (str): The name of the new branch (e.g. 'michael/new-feature')
             access_token(str): Fine-grained token with at least 'Contents' repository write access.
                 https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference--fine-grained-access-tokens
         """
@@ -556,7 +563,8 @@ class GithubTool(metaclass=MetaTool):
             repo (str): The name of the repository
             branch (str): The branch that the commit is being made to.
             commit_message (str): The commit message.
-            access_token(str): Fine-grained token with at least TODO
+            path: (str): Path relative to root of repo
+            access_token(str): Fine-grained token with at least 'Contents' repository write access.
         """
         headers = {
             'Accept': 'application/vnd.github+json',

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -1006,3 +1006,14 @@ class KnowledgeGraphTool(metaclass=MetaTool):
                 return {}
             children = node.children
             return {child.name: child.id for child in children}
+
+    @classmethod
+    def get_root_node(cls, org: str, repo: str) -> UUID | None:
+        """
+        Returns the root node of a repository
+        """
+        with Session() as db:
+            root_node = crud.get_root_repo_node(db=db, org=org, repo=repo)
+            if root_node is None:
+                return None
+            return root_node.id

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -991,3 +991,16 @@ class KnowledgeGraphTool(metaclass=MetaTool):
             if node is None or node.parent_id is None:
                 return None
             return node.parent_id
+
+    @classmethod
+    def get_node_children(cls, node_id: UUID) -> dict[str, UUID]:
+        """
+        Returns the UUIDs of the children of a node.
+        {child_name: child_id}
+        """
+        with Session() as db:
+            node = crud.get_repo_node(db=db, repo_node_id=node_id)
+            if node is None:
+                return {}
+            children = node.children
+            return {child.name: child.id for child in children}

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -653,7 +653,7 @@ class KnowledgeGraphTool(metaclass=MetaTool):
             children_summaries='',
             abs_path=dir_path,
         )
-        if (root_node_id := KnowledgeGraphTool.get_root_node(org, repo)) is not None:
+        if (root_node_id := KnowledgeGraphTool._get_node_by_path(org, repo)) is not None:
             pass
         else:
             with Session() as db:
@@ -1044,7 +1044,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
                 return None
             return node.id
 
-    # ----------------- WIP --------------------
     @classmethod
     def navigate_to_documentation(cls, node_to_document_id: UUID, cur_id: UUID) -> tuple[bool, UUID]:
         """
@@ -1059,7 +1058,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         cur_children_nodes = KnowledgeGraphTool.get_node_children(cur_id)
 
         if not cur_children_nodes:
-            print(cur_children_nodes)
             return (True, cur_id)
 
         from concrete.operators import Executive

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -57,12 +57,13 @@ class MetaTool(type):
                         param_str += f" = {param.default}"
                     params.append(param_str)
 
-                return_str = (
-                    f" -> {signature.return_annotation.__name__}"
-                    if signature.return_annotation != inspect.Signature.empty
-                    and signature.return_annotation is not None
-                    else ""
-                )
+                return_str = ""
+                if signature.return_annotation != inspect.Signature.empty:
+                    if hasattr(signature.return_annotation, '__name__'):
+                        return_str = f" -> {signature.return_annotation.__name__}"
+                    else:
+                        # Handle Union types
+                        return_str = f" -> {str(signature.return_annotation)}"
 
                 method_signature = f"{attr}({', '.join(params)}){return_str}"
                 method_info.append(f"{method_signature}\n\t{docstring}")

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -621,7 +621,7 @@ class KnowledgeGraphTool(metaclass=MetaTool):
     """
 
     @classmethod
-    def parse_to_tree(cls, org: str, repo: str, dir_path: str, rel_gitignore_path: str | None = None) -> UUID:
+    def _parse_to_tree(cls, org: str, repo: str, dir_path: str, rel_gitignore_path: str | None = None) -> UUID:
         """
         Converts a directory into an unpopulated knowledge graph.
         Stored in reponode table. Recursive programming is pain -> use a queue.
@@ -968,3 +968,25 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         elif node.partition_type == 'file':
             return KnowledgeGraphTool._summarize_leaf(node_id)
         return ''
+
+    @classmethod
+    def get_node_summary(cls, node_id: UUID) -> str:
+        """
+        Returns the summary of a node.
+        """
+        with Session() as db:
+            node = crud.get_repo_node(db=db, repo_node_id=node_id)
+            if node is None:
+                return ''
+            return node.summary
+
+    @classmethod
+    def get_node_parent(cls, node_id: UUID) -> UUID | None:
+        """
+        Returns the UUID of the parent of node (if it exists, else None).
+        """
+        with Session() as db:
+            node = crud.get_repo_node(db=db, repo_node_id=node_id)
+            if node is None or node.parent_id is None:
+                return None
+            return node.parent_id

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -877,6 +877,8 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         """
         Updates parent summary with child summary.
         """
+        from concrete.operators import Executive
+
         with Session() as db:
             child = crud.get_repo_node(db=db, repo_node_id=child_node_id)
             if child and child.parent_id:
@@ -890,8 +892,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
             parent_children_summaries = parent.children_summaries
             child_summary = child.summary
             child_abs_path = child.abs_path
-
-        from concrete.operators import Executive
 
         exec = Executive(clients={'openai': OpenAIClient()})
         node_summary: NodeSummary = exec.update_parent_summary(
@@ -922,8 +922,10 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         """
         Creates or overwrites a leaf summary.
         TODO: Current implementation assumes that the leaf is a file - so generated summary is based on file contents.
-        Eventually, this should be able to summ arize functions/classes in a file.
+        Eventually, this should be able to summarize functions/classes in a file.
         """
+        from concrete.operators import Executive
+
         with Session() as db:
             leaf_node = crud.get_repo_node(db=db, repo_node_id=leaf_node_id)
             if leaf_node is not None and leaf_node.abs_path is not None and leaf_node.partition_type == 'file':
@@ -941,8 +943,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         except UnicodeDecodeError:
             contents = raw_data.decode('utf-8', errors='replace')
 
-        from concrete.operators import Executive
-
         exec = Executive(clients={"openai": OpenAIClient()})
         child_node_summary = exec.summarize_file(contents=contents, file_name=path, message_format=ChildNodeSummary)
         repo_node_create = models.RepoNodeUpdate(summary=child_node_summary.summary)
@@ -954,6 +954,8 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         """
         Creates or overwrites a nodes summary using all of its children.
         """
+        from concrete.operators import Executive
+
         with Session() as db:
             parent = crud.get_repo_node(db=db, repo_node_id=repo_node_id)
             if parent is None:
@@ -967,8 +969,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
                 child = crud.get_repo_node(db=db, repo_node_id=child_id)
                 if child is not None:
                     children_summaries.append(f'{child.abs_path}: {child.summary}')
-
-        from concrete.operators import Executive
 
         exec = Executive({"openai": OpenAIClient()})
         node_summary = exec.summarize_from_children(children_summaries, parent_name, message_format=NodeSummary)
@@ -1088,6 +1088,8 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         Recommends documentation a given path.
         Returns a tuple of the (suggested_documentation, documentation_path)
         """
+        from concrete.operators import Executive
+
         root_node_id = KnowledgeGraphTool._get_node_by_path(org=org, repo=repo)
         node_to_document_id = KnowledgeGraphTool._get_node_by_path(org=org, repo=repo, path=path)
         if not node_to_document_id or not root_node_id:
@@ -1109,9 +1111,6 @@ class KnowledgeGraphTool(metaclass=MetaTool):
             existing_documentation = f.read()
         with open(path, 'r') as f:
             module_contents = f.read()
-
-        # Zero-shot w/ existing documentation + path content
-        from concrete.operators import Executive
 
         exec = Executive(clients={"openai": OpenAIClient()})
         suggested_documentation = exec.chat(

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -945,6 +945,8 @@ class KnowledgeGraphTool(metaclass=MetaTool):
         children_summaries = [
             f"{child_summary.node_name}: {child_summary.summary}" for child_summary in node_summary.children_summaries
         ]
+        # Remove children's children summaries.
+        children_summaries = [child_summary.split('Children Summaries:')[0] for child_summary in children_summaries]
         return f"Node Name: {node_name}\nSummary: {overall_summary}\nChildren Summaries:\n" + "\n".join(
             children_summaries
         )

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -1044,6 +1044,8 @@ class KnowledgeGraphTool(metaclass=MetaTool):
                 return None
             return node.id
 
+    # TODO: Reconsider where navigate_to_documentation, and recommend_documentation should live.
+    # They are consumers of the knowledge graph, and not something that should be part of the graph itself.
     @classmethod
     def navigate_to_documentation(cls, node_to_document_id: UUID, cur_id: UUID) -> tuple[bool, UUID]:
         """

--- a/webapp/daemons/server.py
+++ b/webapp/daemons/server.py
@@ -108,7 +108,7 @@ class AOGitHubDaemon(Webhook):
             if payload['action'] == 'opened' or payload['action'] == 'reopened':
                 branch_name = payload['pull_request']['head']['ref']
                 revision_branch_name = f'ghdaemon/revision/{branch_name}'
-                GithubTool.make_branch(
+                GithubTool.create_branch(
                     org='abstractoperators',
                     repo='concrete',
                     base_branch=branch_name,


### PR DESCRIPTION
Knowledge Graph: 
- Rename knowledge graph tool functions
- Add getters for knowledge graph nodes
- Separate node overall summary and child summaries to repo node sqlmodel model
- Add knowledge graph functions for node navigation

GH Daemon:
- Separate JWT Token and Installation Token from Daemon. 
- Add skeletons for calling Knowledge Graph to make commits. 
