### PR TITLE
Update staging webapps to use tailscale subnet router

### DIFF
--- a/.github/workflows/demo_staging.yml
+++ b/.github/workflows/demo_staging.yml
@@ -60,7 +60,13 @@ jobs:
                   curl -sSL https://install.python-poetry.org | python3 -
                   poetry --version
                   poetry install
-                  poetry run python -m concrete deploy --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-demo:latest --container-name webapp-demo-staging --container-port 80 --service-name=webapp-demo-staging
+                  poetry run python -m concrete deploy \
+                    --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-demo:latest \
+                    --container-name demo-staging \
+                    --container-port 80 \
+                    --security-groups sg-01af4e696bd2679c3 \
+                    --subnets subnet-0644cadc735c6b557 \
+                    --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46
 
 # https://github.com/actions/deploy-pages/issues/329 -
 # https://github.com/github/docs/issues/32320 - Explains why id-token write is needed

--- a/.github/workflows/demo_staging.yml
+++ b/.github/workflows/demo_staging.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - main
+            - michael/aws_tailscale
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/demo_staging.yml
+++ b/.github/workflows/demo_staging.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - main
-            - michael/aws_tailscale
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/homepage_staging.yml
+++ b/.github/workflows/homepage_staging.yml
@@ -57,13 +57,13 @@ jobs:
                   poetry --version
                   poetry install
                   poetry run python -m concrete deploy \
-                  --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-homepage:latest \
-                  --container-name homepage-staging \
-                  --container-port 80 \
-                  --service-name homepage-staging \
-                  --security-groups sg-01af4e696bd2679c3 \
-                  --subnets subnet-0644cadc735c6b557 \
-                  --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46
+                    --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-homepage:latest \
+                    --container-name homepage-staging \
+                    --container-port 80 \
+                    --service-name homepage-staging \
+                    --security-groups sg-01af4e696bd2679c3 \
+                    --subnets subnet-0644cadc735c6b557 \
+                    --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46
 # https://github.com/actions/deploy-pages/issues/329 -
 # https://github.com/github/docs/issues/32320 - Explains why id-token write is needed
 # The id-token: write permission provides a workflow the ability to interact with external services that use OpenID Connect (OIDC).

--- a/.github/workflows/homepage_staging.yml
+++ b/.github/workflows/homepage_staging.yml
@@ -56,8 +56,14 @@ jobs:
                   curl -sSL https://install.python-poetry.org | python3 -
                   poetry --version
                   poetry install
-                  poetry run python -m concrete deploy --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-homepage:latest --container-name webapp-homepage-staging --container-port 80 --service-name=webapp-homepage-staging
-
+                  poetry run python -m concrete deploy \
+                  --image-uri 008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-homepage:latest \
+                  --container-name homepage-staging \
+                  --container-port 80 \
+                  --service-name homepage-staging \
+                  --security-groups sg-01af4e696bd2679c3 \
+                  --subnets subnet-0644cadc735c6b557 \
+                  --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46
 # https://github.com/actions/deploy-pages/issues/329 -
 # https://github.com/github/docs/issues/32320 - Explains why id-token write is needed
 # The id-token: write permission provides a workflow the ability to interact with external services that use OpenID Connect (OIDC).

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,12 @@ local-webapp-main:
 # I run `ngrok http 8000`, and then use the forwarding URL as the webhook URL in the GitHub app settings. See webapp/daemons/README.md for more details.
 local-daemons:
 	/bin/bash -c "set -a; source .env.daemons; set +a; cd webapp/daemons && $(POETRY) fastapi dev server.py"
+
+
+# ------------------------ Tailscale -----------------------
+build-tailscale:
+	docker compose -f docker/docker-compose.yml build tailscale
+
+run-tailscale:
+	docker compose -f docker/docker-compose.yml down tailscale 
+	docker compose -f docker/docker-compose.yml up -d tailscale

--- a/concrete/__main__.py
+++ b/concrete/__main__.py
@@ -40,6 +40,17 @@ deploy_parser.add_argument(
     help="The ports for the containers",
 )
 deploy_parser.add_argument("--service-name", type=str, required=False, help="The service name to deploy to AWS")
+deploy_parser.add_argument(
+    "--subnets", type=str, nargs="+", required=False, help="Subnets to be considered for service task placement"
+)
+deploy_parser.add_argument("--vpc", type=str, required=False, help="VPC to be considered for service task placement")
+deploy_parser.add_argument(
+    "--security-groups", type=str, nargs="+", required=False, help="Security groups for the service"
+)
+deploy_parser.add_argument(
+    "--listener-arn", type=str, required=False, help="Listener ARN of Load Balancer for the service"
+)
+
 args = parser.parse_args()
 
 
@@ -63,7 +74,16 @@ async def main():
                 args.image_uri, args.container_name, args.container_port
             )
         ]
-        AwsTool._deploy_service(container_info, args.service_name if args.service_name else None)
+        args_dict = {
+            'service_name': args.service_name,
+            'subnets': args.subnets,
+            'vpc': args.vpc,
+            'security_groups': args.security_groups,
+            'listener_arn': args.listener_arn,
+        }
+        args_dict = {key: value for key, value in args_dict.items() if value is not None}
+
+        AwsTool._deploy_service(containers=container_info, **args_dict)
         CLIClient.emit("Deployment completed.")
 
 

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -318,14 +318,7 @@ class AwsTool(metaclass=MetaTool):
         service_name = service_name or containers[0].container_name
         task_name = service_name
         target_group_name = service_name
-        # vpc = "vpc-022b256b8d0487543"
-        # subnets = ["subnet-0ba67bfb6421d660d"]  # subnets considered for placement
-        # security_group = "sg-0463bb6000a464f50"  # allows traffic from ALB
         execution_role_arn = "arn:aws:iam::008971649127:role/ecsTaskExecutionWithSecret"
-        # listener_arn = (
-        #     "arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteLoadBalancer"
-        #     "/f7cec30e1ac2e4a4/451389d914171f05"
-        # )
 
         # TODO: Load balancer should be able to point to multiple containers on a single service.
         # e.g.) service_name.container1; atm, consider only the first container to route traffic to.

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -280,43 +280,57 @@ class AwsTool(metaclass=MetaTool):
         cpu: int = 256,
         memory: int = 512,
         listener_rule: Optional[dict] = None,
+        subnets: list[str] = ["subnet-0ba67bfb6421d660d"],
+        vpc: str = "vpc-022b256b8d0487543",
+        security_groups: list[str] = ["sg-0463bb6000a464f50"],
+        listener_arn: (
+            str | None
+        ) = "arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteLoadBalancer"
+        "/f7cec30e1ac2e4a4/451389d914171f05",
     ) -> bool:
         """
         containers: [{"image_uri": str, "container_name": str, "container_port": int}]
 
-        service_name (str): Custom service name, defaults to the first container name.
+        service_name (str): Custom service name, defaults to the first container name as host header.
 
         cpu (int): The amount of CPU to allocate to the service. Defaults to 256.
 
         memory (int): The amount of memory to allocate to the service. Defaults to 512
 
         listener_rule: Dictionary of {field: str, value: str} for the listener rule. Defaults to {'field': 'host-header', 'value': f"{service_name}.abop.ai"}}
+
+        subnets (list(str)): List of subnets to consider for placement. Defaults to AZ-a, us-east-1, public
+
+        vpc (str): The VPC to deploy the service in. Defaults to us-east-1
+
+        security_groups (list(str)): List of security groups to attach to the service. Defaults to allow traffic from concrete ALB.
+
+        listener_arn: Arn of the listener to attach to the target group. Defaults to https listener on ConcreteLoadBalancer.
         """  # noqa: E501
-        # TODO: separate out clients and have a better interaction for attaching vars
         import boto3
 
         ecs_client = boto3.client("ecs")
         elbv2_client = boto3.client("elbv2")
 
+        # Arns are not considered secrets
         # https://devops.stackexchange.com/questions/11101/should-aws-arn-values-be-treated-as-secrets
-        # May eventually move these out to env, but not first priority.
         cluster = "DemoCluster"
         service_name = service_name or containers[0].container_name
         task_name = service_name
         target_group_name = service_name
-        vpc = "vpc-022b256b8d0487543"
-        subnets = ["subnet-0ba67bfb6421d660d"]  # subnets considered for placement
-        security_group = "sg-0463bb6000a464f50"  # allows traffic from ALB
+        # vpc = "vpc-022b256b8d0487543"
+        # subnets = ["subnet-0ba67bfb6421d660d"]  # subnets considered for placement
+        # security_group = "sg-0463bb6000a464f50"  # allows traffic from ALB
         execution_role_arn = "arn:aws:iam::008971649127:role/ecsTaskExecutionWithSecret"
-        listener_arn = (
-            "arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteLoadBalancer"
-            "/f7cec30e1ac2e4a4/451389d914171f05"
-        )
+        # listener_arn = (
+        #     "arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteLoadBalancer"
+        #     "/f7cec30e1ac2e4a4/451389d914171f05"
+        # )
 
         # TODO: Load balancer should be able to point to multiple containers on a single service.
         # e.g.) service_name.container1; atm, consider only the first container to route traffic to.
         target_group_arn = None
-        if not listener_rule:
+        if listener_rule is None:
             rule_field = "host-header"
             rule_value = f"{service_name}.abop.ai"
         else:
@@ -331,6 +345,7 @@ class AwsTool(metaclass=MetaTool):
                 and rule["Conditions"][0]["Values"][0] == rule_value
             ):
                 target_group_arn = rule["Actions"][0]["TargetGroupArn"]
+                break
 
         if not target_group_arn:
             # Calculate minimum unused rule priority
@@ -418,7 +433,7 @@ class AwsTool(metaclass=MetaTool):
                 networkConfiguration={
                     "awsvpcConfiguration": {
                         "subnets": subnets,
-                        "securityGroups": [security_group],
+                        "securityGroups": security_groups,
                         "assignPublicIp": "ENABLED",
                     }
                 },

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     environment:
       - SHARED_VOLUME=/shared
     platform: linux/arm64
-
+  
 
 volumes:
   shared-volume:

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -9,7 +9,6 @@
   - Alternatively, call `poetry run python -m concrete deploy --image_uri  <image_uri> --container_name <container_name> --container_port <container_port> [--service_name=<custom_service_name>]`
 * To delete the deployment, delete the service through ECS
   
-
 ## Deploying webapps to tailscale network locally
 
 * Create a directory e.g. homepage
@@ -26,14 +25,27 @@
 * Navigate to `http://<ts_service_name[-i]` to view the service. e.g. `http://ts-oauth-demo-1`.
 
 Optional:
+
 * To make localhost work, add ports to the `ts-oauth-[...]` service in `docker-compose.yml` and run as usual
 
 ## Deploying webapps to tailscale network on AWS
-(transcribed from slack devops tailscale thread)
-It's painful to get Tailscale running on AWS. Tailscale recommends installing it on every device, but sometimes that's infeasible, so they offer subnet routers as an alternative. ECS Fargate services don't expose container-level networking, which makes it impossible(?) to use a Tailscale sidecar container like you can with Docker Compose. I also tried installing Tailscale directly in the webapp service containers, but ran into issues with network mounting and IP tables that I didn't fully understand. Switching to EC2 instances would probably work, but that's a big refactor I don't really want to take on without a clear benefit.
 
-So, the subnet routing approach seems like the most reasonable way to go. With this setup, the actual services aren't directly in the Tailnet—only the router is. The router advertises access to the subnet where these services live, allowing it to reach them since they're in the same VPC. The load balancer, which isn't internet-facing, also sits in this private subnet and directs traffic to the services. The idea is that the subnet router advertises the IP of the internal load balancer, and anyone connected to the Tailnet can access it through the router. For routing, Route 53 reuqires alias subdomain records like `homepage-staging.abop.ai` pointing to the internal load balancer. When users on the Tailnet try to access that URL, the subnet router steps in and makes the internal load balancer accessible, effectively connecting them to the service without exposing it to randos.
+Tailscale recommends installing its client on every device, but this isn't always feasible in AWS environments, particularly with ECS Fargate. Subnet routers offer an alternative solution.
+Challenges:
 
+* ECS Fargate doesn't expose container-level networking, preventing the use of Tailscale sidecar containers.
+* Direct installation in webapp service containers faces network mounting and IP tables issues.
+* Switching to EC2 instances potentially solves the problem requires significant refactoring.
+
+Subnet Routing Solution:
+
+* Services are not directly in the Tailnet; only the subnet router is.
+* The router advertises access to the subnet containing the services, allowing communication since both are in the same VPC.
+* The load balancer, which is not internet-facing, resides in the private subnet and directs traffic to the services.
+* The subnet router advertises the IP of the internal load balancer, enabling anyone connected to the Tailnet to access it through the router.
+* Route 53 requires alias subdomain records (e.g., `homepage-staging.abop.ai`) pointing to the internal load balancer for routing.
+* When Tailnet users access that URL, the subnet router makes the internal load balancer reachable, allowing access to the service without public exposure.
+ 
 ### Actual Steps/Notes
 
 Besides networking differences, deploying a webapp to staging is identical to deploying to production. The only difference is the subnet, security group, and listener/load balancer configuration. This is because the subnet router is the one who is actually connecting to tailnet.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -46,6 +46,7 @@ Besides networking differences, deploying a webapp to staging is identical to de
    3. security group: Must allow inbound traffic from the load balancer
    4. listener: http/https listener arn for the load balancer
       1. load balancer: An internal load balancer with security group only allowing inbound traffic from the subnet router.
+   5. (Note that you don't need to create more of them, just specify the existing resources). Reference homepage_staging.yml for an example.
 3. Add a route 53 A record pointing to the internal load balancer
    1. Subdomain is the service name.
    2. Necessary because there is a default *.abop.ai record pointing to prod load balancer (which points to prod homepage).

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -10,7 +10,7 @@
 * To delete the deployment, delete the service through ECS
   
 
-## Deploying webapps to tailscale network
+## Deploying webapps to tailscale network locally
 
 * Create a directory e.g. homepage
 * Create a corresponding dockerfile in `concrete/docker`, e.g. `Dockerfile.homepage`
@@ -27,6 +27,30 @@
 
 Optional:
 * To make localhost work, add ports to the `ts-oauth-[...]` service in `docker-compose.yml` and run as usual
+
+## Deploying webapps to tailscale network on AWS
+(transcribed from slack devops tailscale thread)
+It's painful to get Tailscale running on AWS. Tailscale recommends installing it on every device, but sometimes that's infeasible, so they offer subnet routers as an alternative. ECS Fargate services don't expose container-level networking, which makes it impossible(?) to use a Tailscale sidecar container like you can with Docker Compose. I also tried installing Tailscale directly in the webapp service containers, but ran into issues with network mounting and IP tables that I didn't fully understand. Switching to EC2 instances would probably work, but that's a big refactor I don't really want to take on without a clear benefit.
+
+So, the subnet routing approach seems like the most reasonable way to go. With this setup, the actual services aren't directly in the Tailnet—only the router is. The router advertises access to the subnet where these services live, allowing it to reach them since they're in the same VPC. The load balancer, which isn't internet-facing, also sits in this private subnet and directs traffic to the services. The idea is that the subnet router advertises the IP of the internal load balancer, and anyone connected to the Tailnet can access it through the router. For routing, Route 53 reuqires alias subdomain records like `homepage-staging.abop.ai` pointing to the internal load balancer. When users on the Tailnet try to access that URL, the subnet router steps in and makes the internal load balancer accessible, effectively connecting them to the service without exposing it to randos.
+
+### Actual Steps/Notes
+
+Besides networking differences, deploying a webapp to staging is identical to deploying to production. The only difference is the subnet, security group, and listener/load balancer configuration. This is because the subnet router is the one who is actually connecting to tailnet.
+
+1. Create and push a docker image to ECR as normal
+2. Use `AwsTool._deploy_service` or the CLI to deploy the image to ECS.
+   1. MUST SPECIFY subnet, security group, and listener ARN
+   2. subnet: Must be a public subnet in the same availability zone as the load balancer.
+      1. [there's other solutions besides public subnet, but this is easiest](https://stackoverflow.com/questions/61265108/aws-ecs-fargate-resourceinitializationerror-unable-to-pull-secrets-or-registry)
+   3. security group: Must allow inbound traffic from the load balancer
+   4. listener: http/https listener arn for the load balancer
+      1. load balancer: An internal load balancer with security group only allowing inbound traffic from the subnet router.
+3. Add a route 53 A record pointing to the internal load balancer
+   1. Subdomain is the service name.
+   2. Necessary because there is a default *.abop.ai record pointing to prod load balancer (which points to prod homepage).
+
+Subnet Router: You don't need to do anything to create the subnet router. It's on AWS already, and won't be reinstantiated or anything. SSH key to it is in `Tailscale Subnet Router` in 1Password, `ssh -i <key> ubuntu@3.81.140.147`. Initial creation entailed following this [tutorial](https://tailscale.com/kb/1019/subnets) to advertise the route for the CIDR blocks of the internal load balancer.
 
 ## Docs server
 Use the make commands from root of concrete


### PR DESCRIPTION
Add vpc, subnet, security groups, and listener arn to `AwsTool._deploy_service`
Update CLI to include those options
Update deploy to staging workflows to use newly created subnet router.
Add docs on how to deploy websites to staging environment with whitelist access through tailscale. 
