### PR TITLE
Make operator instantiation arg-less

### DIFF
--- a/concrete/abstract.py
+++ b/concrete/abstract.py
@@ -109,8 +109,8 @@ class MetaAbstractOperator(type):
 class AbstractOperator(metaclass=MetaAbstractOperator):
 
     # TODO replace OpenAIClient with GenericClient
-    def __init__(self, clients: dict[str, OpenAIClient], tools: list[MetaTool] | None = None):
-        self._clients = clients
+    def __init__(self, clients: dict[str, OpenAIClient] | None = None, tools: list[MetaTool] | None = None):
+        self._clients = clients if clients is not None else {'openai': OpenAIClient()}
         self.llm_client = "openai"
         self.llm_client_function = "complete"
         self.tools = tools


### PR DESCRIPTION
* Allows `operators.Operators()` without explicitly passing in a client as before