### PR TITLE
Operators Refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ helloworld:
 # Requires rabbitmq and celery worker to be running
 helloworld_celery: celery
 	sleep 10
-	$(ORCHESTRATE) "Create a simple hello world program" --celery
+	$(ORCHESTRATE) "Create a simple hello world program" --run-async
 	
 simpleflask:
 	$(ORCHESTRATE) "Provide the code for a flask application. The applicataion should have a single route that renders the HTML template 'index.html'. The template should contain a single header tag with the text 'Hello, World!'."

--- a/concrete/__main__.py
+++ b/concrete/__main__.py
@@ -77,7 +77,9 @@ args = parser.parse_args()
 async def main():
     if args.mode == "prompt":
         so = orchestrator.SoftwareOrchestrator()
-        async for operator, response in so.process_new_project(args.prompt, deploy=args.deploy, run_async=args.celery):
+        async for operator, response in so.process_new_project(
+            args.prompt, deploy=args.deploy, run_async=args.run_async
+        ):
             CLIClient.emit(f"[{operator}]:\n{response}\n")
 
     elif args.mode == "deploy":

--- a/concrete/__main__.py
+++ b/concrete/__main__.py
@@ -13,7 +13,7 @@ prompt_parser = subparsers.add_parser("prompt", help="Generate a response for th
 prompt_parser.add_argument("prompt", type=str, help="The prompt to generate a response for")
 prompt_parser.add_argument("--deploy", action="store_true", help="Deploy the project to AWS")
 prompt_parser.add_argument(
-    "--celery",
+    "--run-async",
     action="store_true",
     help="Use celery for processing. Otherwise, use plain.",
 )
@@ -77,7 +77,7 @@ args = parser.parse_args()
 async def main():
     if args.mode == "prompt":
         so = orchestrator.SoftwareOrchestrator()
-        async for operator, response in so.process_new_project(args.prompt, deploy=args.deploy, use_celery=args.celery):
+        async for operator, response in so.process_new_project(args.prompt, deploy=args.deploy, run_async=args.celery):
             CLIClient.emit(f"[{operator}]:\n{response}\n")
 
     elif args.mode == "deploy":

--- a/concrete/abstract.py
+++ b/concrete/abstract.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from collections.abc import Callable
-from functools import cache, partial, wraps
+from functools import cache, wraps
 from typing import Any, cast
 from uuid import UUID, uuid4
 
@@ -11,9 +11,9 @@ from .celery import app
 from .clients import CLIClient, OpenAIClient
 from .db import crud
 from .db.orm import Session
-from .db.orm.models import MessageCreate
+from .db.orm.models import MessageCreate, OperatorOptions
 from .models.clients import ConcreteChatCompletion, OpenAIClientModel
-from .models.messages import Message, TextMessage
+from .models.messages import Message
 from .models.operations import Operation
 from .tools import MetaTool
 
@@ -45,7 +45,12 @@ def abstract_operation(operation: Operation, clients: dict[str, OpenAIClientMode
     """
 
     client = OpenAIClient(**clients[operation.client_name].model_dump())
+    # func = e.g. OpenAIClient.complete
     func: Callable[..., ChatCompletion] = getattr(client, operation.function_name)
+    # res = e.g. OpenAIClient.complete(
+    #   messages=[{"role": "system", ...}, {"role": "user", ...}]
+    #   message_format=response_format
+    # )
     res = func(**operation.arg_dict).model_dump()
 
     message_format_name = cast(dict, operation.arg_dict["message_format"])["json_schema"]["name"]
@@ -65,24 +70,24 @@ class MetaAbstractOperator(type):
 
     def __new__(cls, clsname, bases, attrs):
         # identify methods and add delay functionality
-        def _delay_factory(func: Callable[..., str]) -> Callable[..., AsyncResult]:
+        def _delay_factory(string_func: Callable[..., str]) -> Callable[..., AsyncResult]:
 
             def _delay(
                 self: "AbstractOperator",
                 *args,
-                clients: dict[str, OpenAIClient] | None = None,
-                client_name: str | None = None,
-                client_function: str | None = None,
-                message_format: type[Message] = TextMessage,
+                extra_kwargs: OperatorOptions,
                 **kwargs,
             ) -> AsyncResult:
-
+                # Pop extra kwargs and set defaults
                 operation = Operation(
-                    client_name=client_name or self.llm_client,
-                    function_name=client_function or self.llm_client_function,
+                    client_name=self.llm_client,
+                    function_name=self.llm_client_function,
                     arg_dict={
-                        "messages": [{"role": "user", "content": func(self, **kwargs)}],
-                        "message_format": OpenAIClient.model_to_schema(message_format),
+                        "messages": [
+                            {"role": "system", "content": OperatorOptions.instructions},
+                            {"role": "user", "content": string_func(self, *args, **kwargs)},
+                        ],
+                        "message_format": OpenAIClient.model_to_schema(extra_kwargs.response_format),
                     },
                 )
                 # TODO unhardcode client conversion
@@ -91,7 +96,7 @@ class MetaAbstractOperator(type):
                         model=client.model,
                         temperature=client.default_temperature,
                     )
-                    for name, client in (clients or self.clients).items()
+                    for name, client in (self.clients).items()
                 }
                 operation_result = abstract_operation.delay(
                     operation=operation, clients=client_models
@@ -154,7 +159,7 @@ class AbstractOperator(metaclass=MetaAbstractOperator):
             self.clients["openai"]
             .complete(
                 messages=messages,
-                response_format=response_format,
+                message_format=response_format,
             )
             .choices[0]
             .message
@@ -191,28 +196,44 @@ class AbstractOperator(metaclass=MetaAbstractOperator):
         @wraps(question_producer)
         def _send_and_await_reply(
             *args,
-            instructions: str | None = None,
+            extra_kwargs: OperatorOptions,
             **kwargs,
         ):
-            response_format = kwargs.pop("message_format", TextMessage)
+            """
+            extra_kwargs (dict): can contain extra options:
+                response_format ([PydanticModel, ConcreteModel]): something json-like
+                run_async (bool): whether to use the celery .delay function
+                use_tools (bool):  whether to use tools set on the operator
 
-            tools = (
-                explicit_tools
-                if (explicit_tools := kwargs.pop("tools", []))
-                else (self.tools if kwargs.pop("use_tools", False) else [])
-            )
-
-            query = question_producer(*args, **kwargs)
-
-            # Add additional prompt to inform agent about tools
-            if tools:
+                # Clobbers the Operator instance attributes
+                instructions (str): override system prompt
+                tools (list[concrete.models.MetaTool]): list of tools available for the operator
+            """
+            # Pop extra kwargs and set defaults
+            tools_addendum = ""
+            if tools := (
+                extra_kwargs.tools
+                if extra_kwargs.tools
+                # TODO Have a multi-select drop down in the SaaS
+                else (self.tools if extra_kwargs.use_tools else [])
+            ):
                 # LLMs don't really know what should go in what field even if output struct
                 # is guaranteed
-                query += """Here are your available tools:\
+                tools_addendum = """Here are your available tools:\
     Either call the tool with the specified syntax, or leave its field blank.\n"""
                 for tool in tools:
-                    query += str(tool)
-            return self._qna(query, response_format=response_format, instructions=instructions)
+                    tools_addendum += str(tool)
+
+            # Fetch underlying prompt, post string interpolation
+            query = question_producer(*args, **kwargs)
+            query += tools_addendum
+
+            # Process the finalized query
+            return self._qna(
+                query,
+                response_format=extra_kwargs.response_format,
+                instructions=extra_kwargs.instructions,
+            )
 
         return _send_and_await_reply
 
@@ -238,20 +259,27 @@ class AbstractOperator(metaclass=MetaAbstractOperator):
         if name.startswith("__") or name in {"qna", "_qna"} or not callable(attr):
             return attr
 
-        # Only wrap with qna if the result is a string.
-        # Impossible to figure out return type without running it
         def wrapped_func(*args, **kwargs):
-            result = attr(*args, **kwargs)
-            if isinstance(result, str):
-                str_func = self.qna(attr)
-                str_func.delay = partial(str_func._delay, self)
-                return str_func(*args, **kwargs)
+            extra_kwargs = OperatorOptions(**(self._extra_kwargs | kwargs.pop("extra_kwargs", {})))
 
-            return result
+            result = attr(*args, extra_kwargs=extra_kwargs.model_dump(), **kwargs)
+            assert isinstance(result, str)
+
+            llm_func = self.qna(attr)
+            if extra_kwargs.run_async:
+                # TODO: Converts args into kwargs for this function
+                # Return an async job if requested
+                return llm_func._delay(self, *args, extra_kwargs=extra_kwargs, **kwargs)
+
+            return llm_func(*args, extra_kwargs=extra_kwargs, **kwargs)
 
         return wrapped_func
 
-    def chat(self, message: str, *args, **kwargs) -> str:
+    @property
+    def _extra_kwargs(self) -> dict[str, Any]:
+        return {'instructions': self.instructions}
+
+    def chat(self, message: str, extra_kwargs: dict[str, Any]) -> str:
         """
         Chat with the operator with a direct message.
         """

--- a/concrete/abstract.py
+++ b/concrete/abstract.py
@@ -260,10 +260,11 @@ class AbstractOperator(metaclass=MetaAbstractOperator):
             return attr
 
         def wrapped_func(*args, **kwargs):
-            options = OperatorOptions(**(self._options | kwargs.pop("options")))
+            options = OperatorOptions(**(self._options | kwargs.pop("options", {})))
 
             result = attr(*args, options=options.model_dump(), **kwargs)
-            assert isinstance(result, str)
+            if not isinstance(result, str):
+                return result
 
             llm_func = self.qna(attr)
             if options.run_async:

--- a/concrete/clients.py
+++ b/concrete/clients.py
@@ -14,6 +14,8 @@ from tenacity import (
     wait_random_exponential,
 )
 
+from concrete.models.base import ConcreteModel
+
 from .models.messages import Message, TextMessage
 
 
@@ -68,7 +70,7 @@ class OpenAIClient(Client):
             raise e  # retry decorator
 
     @staticmethod
-    def model_to_schema(model: type[PydanticModel]) -> dict[str, str | dict]:
+    def model_to_schema(model: type[PydanticModel] | type[ConcreteModel]) -> dict[str, str | dict]:
         """
         Utility for formatting a pydantic model into a json output for OpenAI.
         """

--- a/concrete/clients.py
+++ b/concrete/clients.py
@@ -14,8 +14,6 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from concrete.models.base import ConcreteModel
-
 from .models.messages import Message, TextMessage
 
 
@@ -70,7 +68,7 @@ class OpenAIClient(Client):
             raise e  # retry decorator
 
     @staticmethod
-    def model_to_schema(model: type[PydanticModel] | type[ConcreteModel]) -> dict[str, str | dict]:
+    def model_to_schema(model: type[PydanticModel]) -> dict[str, str | dict]:
         """
         Utility for formatting a pydantic model into a json output for OpenAI.
         """

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -526,3 +526,6 @@ class OperatorOptions(Base):
         description="List of tools to override the operator's tools",
         default=[],
     )
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -164,9 +164,12 @@ class Operator(OperatorBase, MetadataMixin, table=True):
 
         # TODO: Abide by orchestrator clients
         if self.title == 'executive':
-            operator = Executive()
-        if self.title == 'developer':
-            operator = Developer()
+            operator = Executive(store_messages=True)
+        elif self.title == 'developer':
+            operator = Developer(store_messages=True)
+        else:
+            # Otherwise just use a normal Operator
+            operator = Operator(store_messages=True)
         operator.operator_id = self.id
         operator.instructions = self.instructions
         return operator

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -9,7 +9,10 @@ from sqlalchemy.schema import Index
 from sqlalchemy.sql import func
 from sqlmodel import Field, Relationship, SQLModel
 
+from ...models.messages import Message as ConcreteMessage
+from ...models.messages import TextMessage
 from ...state import ProjectStatus
+from ...tools import MetaTool
 
 
 class Base(SQLModel):
@@ -500,3 +503,26 @@ class AuthTokenCreate(AuthTokenBase):
 
 class AuthToken(AuthTokenBase, MetadataMixin, table=True):
     user: User = Relationship(back_populates="auth_token")
+
+
+class OperatorOptions(Base):
+    response_format: type[ConcreteMessage] = Field(
+        description="Response format to be returned by LLM",
+        default=TextMessage,
+    )
+    run_async: bool = Field(
+        description="Whether to use the celery .delay function",
+        default=False,
+    )
+    use_tools: bool = Field(
+        description="Whether to use tools set on the operator",
+        default=False,
+    )
+
+    instructions: str = Field(
+        description="Instructions to override system prompt",
+    )
+    tools: list[MetaTool] = Field(
+        description="List of tools to override the operator's tools",
+        default=[],
+    )

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -527,5 +527,4 @@ class OperatorOptions(Base):
         default=[],
     )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = {"arbitrary_types_allowed": True}

--- a/concrete/db/orm/models.py
+++ b/concrete/db/orm/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Self, cast
 from uuid import UUID, uuid4
 
-from pydantic import ValidationError, model_validator
+from pydantic import ConfigDict, ValidationError, model_validator
 from sqlalchemy import CheckConstraint, DateTime
 from sqlalchemy.schema import Index
 from sqlalchemy.sql import func
@@ -527,4 +527,4 @@ class OperatorOptions(Base):
         default=[],
     )
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = ConfigDict(arbitrary_types_allowed=True)  # type: ignore

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -30,7 +30,7 @@ class Developer(Operator):
         Leverage your technical expertise to create robust, scalable, and innovative AI agent orchestration systems. Apply clarity, completeness, specificity, adaptability, and creativity to deliver high-quality, impactful solutions.
     """  # noqa E501
 
-    def ask_question(self, context: str, *args, **kwargs) -> str:
+    def ask_question(self, context: str, extra_kwargs: dict) -> str:
         """
         Accept instructions and ask a question about it if necessary.
 
@@ -64,7 +64,7 @@ class Developer(Operator):
                 What should the function be called?"""
         )
 
-    def implement_component(self, context: str, *args, **kwargs) -> str:
+    def implement_component(self, context: str, extra_kwargs: dict) -> str:
         """
         Prompts the Operator to implement a component based off of the components context.
         Returns the code for the component
@@ -103,7 +103,7 @@ First, think about all files you intend to use in the final output. Then, combin
             """  # noqa E501
         return out_str
 
-    def implement_html_element(self, prompt: str, *args, **kwargs) -> str:
+    def implement_html_element(self, prompt: str, extra_kwargs: dict) -> str:
         out_str = f"""\
 Generate an html element with the following description:\n
 {prompt}
@@ -159,7 +159,7 @@ class Executive(Operator):
         growth objectives.
     """
 
-    def plan_components(self, starting_prompt, *args, **kwargs) -> str:
+    def plan_components(self, starting_prompt, extra_kwargs: dict) -> str:
         return """\
 List the essential code components required to implement the project idea. Each component should be atomic, \
 such that a developer could implement it in isolation provided placeholders for preceding components.
@@ -180,7 +180,7 @@ Project Idea:
             starting_prompt=starting_prompt
         )
 
-    def answer_question(self, context: str, question: str, *args, **kwargs) -> str:
+    def answer_question(self, context: str, question: str, extra_kwargs: dict) -> str:
         """
         Prompts the Operator to answer a question
         Returns the answer
@@ -191,7 +191,7 @@ Project Idea:
             "If there is no question, then respond with 'Okay'. Do not provide clarification unprompted."
         )
 
-    def generate_summary(self, summary: str, implementation: str, *args, **kwargs) -> str:
+    def generate_summary(self, summary: str, implementation: str, extra_kwargs: dict) -> str:
         """
         Generates a summary of completed components
         Returns the summary
@@ -215,7 +215,7 @@ Previous Components: {summary}"""  # noqa E501
         return prompt
 
     def update_parent_summary(
-        self, parent_summary: str, child_summary: str, parent_child_summaries: str, child_name: str, *args, **kwargs
+        self, parent_summary: str, child_summary: str, parent_child_summaries: str, child_name: str, extra_kwargs: dict
     ) -> str:
         """
         Updates the parent summary with the child summary
@@ -252,7 +252,7 @@ Guidelines:
 - Each child summary should accurately represent its corresponding node.
 """  # noqa
 
-    def summarize_file(self, contents: str, file_name: str, *args, **kwargs) -> str:
+    def summarize_file(self, contents: str, file_name: str, extra_kwargs: dict) -> str:
         return f"""Provide a concise summary of the following file, focusing on its purpose and the key functionalities of its contents. 
 The summary should give a high-level overview that explains what the file is for and its primary components or actions. Keep critical implementation details in mind.
 Return the summary in one paragraph.
@@ -265,7 +265,7 @@ node_name: <Name>
 summary: <summary of file contents>
 """  # noqa
 
-    def summarize_from_children(self, children_summaries: list[str], parent_name: str, *args, **kwargs) -> str:
+    def summarize_from_children(self, children_summaries: list[str], parent_name: str, extra_kwargs: dict) -> str:
         joined_summaries = "\n\n".join(children_summaries)
         return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality. Keep critical implementation details in children summaries in mind.
     

--- a/concrete/operators.py
+++ b/concrete/operators.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+from typing import Any
 
 from .abstract import AbstractOperator
 
@@ -30,7 +31,7 @@ class Developer(Operator):
         Leverage your technical expertise to create robust, scalable, and innovative AI agent orchestration systems. Apply clarity, completeness, specificity, adaptability, and creativity to deliver high-quality, impactful solutions.
     """  # noqa E501
 
-    def ask_question(self, context: str, extra_kwargs: dict) -> str:
+    def ask_question(self, context: str, options: dict[str, Any] = {}) -> str:
         """
         Accept instructions and ask a question about it if necessary.
 
@@ -64,7 +65,7 @@ class Developer(Operator):
                 What should the function be called?"""
         )
 
-    def implement_component(self, context: str, extra_kwargs: dict) -> str:
+    def implement_component(self, context: str, options: dict[str, Any] = {}) -> str:
         """
         Prompts the Operator to implement a component based off of the components context.
         Returns the code for the component
@@ -80,8 +81,7 @@ Use placeholders referencing code/functions already provided in the context. Nev
         planned_components: list[str],
         implementations: list[str],
         idea: str,
-        *args,
-        **kwargs,
+        options: dict[str, Any] = {},
     ) -> str:
         """
         Prompts Operator to combine code implementations of multiple components
@@ -103,7 +103,7 @@ First, think about all files you intend to use in the final output. Then, combin
             """  # noqa E501
         return out_str
 
-    def implement_html_element(self, prompt: str, extra_kwargs: dict) -> str:
+    def implement_html_element(self, prompt: str, options: dict[str, Any] = {}) -> str:
         out_str = f"""\
 Generate an html element with the following description:\n
 {prompt}
@@ -159,7 +159,7 @@ class Executive(Operator):
         growth objectives.
     """
 
-    def plan_components(self, starting_prompt, extra_kwargs: dict) -> str:
+    def plan_components(self, starting_prompt, options: dict[str, Any] = {}) -> str:
         return """\
 List the essential code components required to implement the project idea. Each component should be atomic, \
 such that a developer could implement it in isolation provided placeholders for preceding components.
@@ -180,7 +180,7 @@ Project Idea:
             starting_prompt=starting_prompt
         )
 
-    def answer_question(self, context: str, question: str, extra_kwargs: dict) -> str:
+    def answer_question(self, context: str, question: str, options: dict[str, Any] = {}) -> str:
         """
         Prompts the Operator to answer a question
         Returns the answer
@@ -191,7 +191,7 @@ Project Idea:
             "If there is no question, then respond with 'Okay'. Do not provide clarification unprompted."
         )
 
-    def generate_summary(self, summary: str, implementation: str, extra_kwargs: dict) -> str:
+    def generate_summary(self, summary: str, implementation: str, options: dict[str, Any] = {}) -> str:
         """
         Generates a summary of completed components
         Returns the summary
@@ -215,7 +215,12 @@ Previous Components: {summary}"""  # noqa E501
         return prompt
 
     def update_parent_summary(
-        self, parent_summary: str, child_summary: str, parent_child_summaries: str, child_name: str, extra_kwargs: dict
+        self,
+        parent_summary: str,
+        child_summary: str,
+        parent_child_summaries: str,
+        child_name: str,
+        options: dict[str, Any] = {},
     ) -> str:
         """
         Updates the parent summary with the child summary
@@ -252,7 +257,7 @@ Guidelines:
 - Each child summary should accurately represent its corresponding node.
 """  # noqa
 
-    def summarize_file(self, contents: str, file_name: str, extra_kwargs: dict) -> str:
+    def summarize_file(self, contents: str, file_name: str, options: dict[str, Any] = {}) -> str:
         return f"""Provide a concise summary of the following file, focusing on its purpose and the key functionalities of its contents. 
 The summary should give a high-level overview that explains what the file is for and its primary components or actions. Keep critical implementation details in mind.
 Return the summary in one paragraph.
@@ -265,7 +270,12 @@ node_name: <Name>
 summary: <summary of file contents>
 """  # noqa
 
-    def summarize_from_children(self, children_summaries: list[str], parent_name: str, extra_kwargs: dict) -> str:
+    def summarize_from_children(
+        self,
+        children_summaries: list[str],
+        parent_name: str,
+        options: dict[str, Any] = {},
+    ) -> str:
         joined_summaries = "\n\n".join(children_summaries)
         return f"""Summarize the following by aggregating the following children. Deliver a high-level overview. Ensure ALL children and their summaries are captured. Emphasize the summaries of children core to the application's functionality. Keep critical implementation details in children summaries in mind.
     

--- a/concrete/orchestrator.py
+++ b/concrete/orchestrator.py
@@ -259,6 +259,10 @@ async def communicative_dehallucination(
     # TODO: synchronize message persistence and websocket messages
     # yield Executive.__name__, component
     # Iterative Q&A process
+
+    # TODO: Remove .delay in favor of run_async
+    # TODO: Switch to extra_kwargs
+    # TODO: Test out makefile helloworld, saas, and celery helloworld?
     q_and_a = []
     for _ in range(max_iter):
         if celery:
@@ -287,7 +291,9 @@ async def communicative_dehallucination(
 
     if celery:
         implementation: ProjectFile = (
-            developer.implement_component.delay(context=context, message_format=ProjectFile).get().message
+            developer.implement_component.delay(context=context, extra_kwargs={'response_format': ProjectFile})
+            .get()
+            .message
         )
     else:
         implementation: ProjectFile = developer.implement_component(context, message_format=ProjectFile)  # type: ignore

--- a/concrete/orchestrator.py
+++ b/concrete/orchestrator.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import AsyncGenerator
 from textwrap import dedent
-from typing import Optional
 from uuid import UUID, uuid1, uuid4
 
 from . import prompts
@@ -38,8 +37,8 @@ class SoftwareProject(StatefulMixin):
         exec: Executive,
         dev: Developer,
         clients: dict[str, Client_con],
-        deploy: bool = False,
-        use_celery: bool = True,
+        deploy: bool,
+        run_async: bool,
     ):
         self.state = State(self, orchestrator=orchestrator)
         self.uuid = uuid1()  # suffix is unique based on network id
@@ -51,21 +50,23 @@ class SoftwareProject(StatefulMixin):
         self.results = None
         self.update(status=ProjectStatus.READY)
         self.deploy = deploy
-        self.use_celery = use_celery
+        self.run_async = run_async
 
-    def do_work(self) -> AsyncGenerator[tuple[str, str], None]:
+    async def do_work(self) -> AsyncGenerator[tuple[str, str], None]:
         """
         Break down prompt into smaller components and write the code for each individually.
         """
         self.update(status=ProjectStatus.WORKING)
-        if self.use_celery:
-            return self._do_work_celery()
-        return self._do_work_plain()
 
-    async def _do_work_plain(self) -> AsyncGenerator[tuple[str, str], None]:
         planned_components_resp: PlannedComponents = self.exec.plan_components(
-            self.starting_prompt, message_format=PlannedComponents
+            self.starting_prompt,
+            options={
+                "response_format": PlannedComponents,
+                "run_async": self.run_async,
+            },
         )  # type: ignore
+        if self.run_async:
+            planned_components_resp = planned_components_resp.get().message
         components: list[str] = planned_components_resp.components
         yield Executive.__name__, str(planned_components_resp)
 
@@ -78,6 +79,7 @@ class SoftwareProject(StatefulMixin):
                 self.dev,
                 summary,
                 component,
+                self.run_async,
                 starting_prompt=self.starting_prompt,
                 max_iter=0,
             ):
@@ -91,8 +93,13 @@ class SoftwareProject(StatefulMixin):
             components,
             all_implementations,
             self.starting_prompt,
-            message_format=ProjectDirectory,
+            options={
+                "response_format": ProjectDirectory,
+                "run_async": self.run_async,
+            },
         )
+        if self.run_async:
+            files = files.get().message
 
         if self.deploy:
             # TODO Use an actual DB instead of emulating one with a dictionary
@@ -102,64 +109,12 @@ class SoftwareProject(StatefulMixin):
 
             deploy_tool_call: Tool = self.dev.chat(
                 f"""Deploy the provided project to AWS. The project directory is: {files}""",
-                tools=[AwsTool],
-                message_format=Tool,
+                options={
+                    "tools": [AwsTool],
+                    "response_format": Tool,
+                },
             )  # type: ignore
             invoke_tool(**deploy_tool_call.model_dump())  # dict() is deprecated
-
-        self.update(status=ProjectStatus.FINISHED)
-        yield Developer.__name__, str(files)
-
-    # TODO: implement using Celery task calls
-    async def _do_work_celery(self) -> AsyncGenerator[tuple[str, str], None]:
-        planned_components_resp: PlannedComponents = (
-            self.exec.plan_components.delay(
-                starting_prompt=self.starting_prompt, message_format=PlannedComponents
-            ).get()
-        ).message
-        components: list[str] = planned_components_resp.components
-
-        yield Executive.__name__, "\n".join(components)
-
-        summary = ""
-        all_implementations = []
-        for component in components:
-            # Use communicative_dehallucination for each component
-            async for agent_or_implementation, message in communicative_dehallucination(
-                self.exec,
-                self.dev,
-                summary,
-                component,
-                starting_prompt=self.starting_prompt,
-                max_iter=0,
-                celery=True,
-            ):
-                if agent_or_implementation in (Developer.__name__, Executive.__name__):
-                    yield agent_or_implementation, message
-                else:  # last result
-                    all_implementations.append(agent_or_implementation)
-                    summary = message
-        files: ProjectDirectory = (
-            self.dev.integrate_components.delay(
-                planned_components=components,
-                implementations=all_implementations,
-                idea=self.starting_prompt,
-                message_format=ProjectDirectory,
-            ).get()
-        ).message
-
-        if self.deploy:
-            # TODO Use an actual DB instead of emulating one with a dictionary
-            yield "executive", "Deploying to AWS"
-            AwsTool.results.update({files.project_name: json.loads(files.__repr__())})
-
-            deploy_tool_call: Tool = self.dev.chat.delay(
-                message=f"Deploy the provided project to AWS. The project directory is: {files}",
-                tools=[AwsTool],
-                message_format=Tool,
-            ).message
-
-            invoke_tool(**deploy_tool_call.model_dump())
 
         self.update(status=ProjectStatus.FINISHED)
         yield Developer.__name__, str(files)
@@ -185,7 +140,7 @@ class SoftwareOrchestrator(Orchestrator, StatefulMixin):
         self.update(status=ProjectStatus.READY)
         self.operators = {'exec': Executive(self.clients), 'dev': Developer(self.clients)}
 
-    def add_operator(self, operator: "Operator", title: str) -> None:
+    def add_operator(self, operator: Operator, title: str) -> None:
         self.operators[title] = operator
 
     def process_new_project(
@@ -193,7 +148,7 @@ class SoftwareOrchestrator(Orchestrator, StatefulMixin):
         starting_prompt: str,
         project_id: UUID = uuid4(),
         deploy: bool = False,
-        use_celery: bool = True,
+        run_async: bool = False,
         exec: str | None = None,
         dev: str | None = None,
     ) -> AsyncGenerator[tuple[str, str], None]:
@@ -218,7 +173,7 @@ class SoftwareOrchestrator(Orchestrator, StatefulMixin):
             orchestrator=self,
             clients=self.clients,
             deploy=deploy,
-            use_celery=use_celery,
+            run_async=run_async,
         )
         return current_project.do_work()
 
@@ -228,9 +183,9 @@ async def communicative_dehallucination(
     developer: Developer,
     summary: str,
     component: str,
+    run_async: bool,
     max_iter: int = 1,
-    starting_prompt: Optional[str] = None,
-    celery: bool = False,
+    starting_prompt: str | None = None,
 ) -> AsyncGenerator[tuple[str, str], None]:
     """
     Implements a communicative dehallucination process for software development.
@@ -240,8 +195,9 @@ async def communicative_dehallucination(
         developer (Developer): The developer assistant object for asking questions and implementing.
         summary (str): A summary of previously implemented components.
         component (str): The current component to be implemented.
-        starting_prompt (str): The initial prompt for the project.
-        max_iter (int, optional): Maximum number of Q&A iterations.
+        run_async (bool): Whether to complete process via Celery calls.
+        starting_prompt (str, default = None): The initial prompt for the project.
+        max_iter (int, default = 1): Maximum number of Q&A iterations.
 
     Returns:
         tuple: A tuple containing:
@@ -260,25 +216,22 @@ async def communicative_dehallucination(
     # yield Executive.__name__, component
     # Iterative Q&A process
 
-    # TODO: Remove .delay in favor of run_async
-    # TODO: Switch to extra_kwargs
     # TODO: Test out makefile helloworld, saas, and celery helloworld?
+    run_async_kwarg = {"run_async": run_async}
     q_and_a = []
     for _ in range(max_iter):
-        if celery:
-            question: TextMessage = developer.ask_question.delay(context=context).get().message
-        else:
-            question: TextMessage = developer.ask_question(context)  # type: ignore
+        question: TextMessage = developer.ask_question(context, options=run_async_kwarg).get().message
+        if run_async:
+            question = question.get().message
 
         if question == "No Question":
             break
 
         yield Developer.__name__, question.text
 
-        if celery:
-            answer: TextMessage = executive.answer_question.delay(context=context, question=question).get().message
-        else:
-            answer: TextMessage = executive.answer_question(context, question)  # type: ignore
+        answer: TextMessage = executive.answer_question(context, question, options=run_async_kwarg)  # type: ignore
+        if run_async:
+            answer = answer.get().message
         q_and_a.append((question, answer))
 
         yield Executive.__name__, answer.text
@@ -289,31 +242,24 @@ async def communicative_dehallucination(
             context += f"\nQuestion: {question}"
             context += f"\nAnswer: {answer}"
 
-    if celery:
-        implementation: ProjectFile = (
-            developer.implement_component.delay(context=context, extra_kwargs={'response_format': ProjectFile})
-            .get()
-            .message
-        )
-    else:
-        implementation: ProjectFile = developer.implement_component(context, message_format=ProjectFile)  # type: ignore
+    implementation: ProjectFile = developer.implement_component(  # type: ignore
+        context,
+        options=run_async_kwarg | {"response_format": ProjectFile},
+    )
+    if run_async:
+        implementation = implementation.get().message
 
     yield Developer.__name__, str(implementation)
 
-    if celery:
-        new_summary: Summary = (
-            executive.generate_summary.delay(
-                summary=summary,
-                implementation=str(implementation),
-                message_format=Summary,
-            )
-            .get()
-            .message
-        )  # type: ignore
+    new_summary: Summary = executive.generate_summary(  # type: ignore
+        summary,
+        str(implementation),
+        options=run_async_kwarg | {"response_format": Summary},
+    )
+    if run_async:
+        new_summary = new_summary.get().message
     else:
-        new_summary: Summary = executive.generate_summary(  # type: ignore
-            summary, str(implementation), message_format=Summary
-        ).summary
+        new_summary = new_summary.summary  # type: ignore
 
     yield Executive.__name__, str(new_summary)
 

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -1016,7 +1016,7 @@ class KnowledgeGraphTool(metaclass=MetaTool):
 
         exec = Executive(clients={"openai": OpenAIClient()})
         child_node_summary = exec.summarize_file(
-            contents=contents, file_name=path, extra_kwargs={'message_format': ChildNodeSummary}
+            contents=contents, file_name=path, options={'message_format': ChildNodeSummary}
         )
         repo_node_create = models.RepoNodeUpdate(summary=child_node_summary.summary)
         with Session() as db:
@@ -1045,7 +1045,7 @@ class KnowledgeGraphTool(metaclass=MetaTool):
 
         exec = Executive({"openai": OpenAIClient()})
         node_summary = exec.summarize_from_children(
-            children_summaries, parent_name, extra_kwargs={'message_format': NodeSummary}
+            children_summaries, parent_name, options={'message_format': NodeSummary}
         )
         overall_summary = node_summary.overall_summary
         parent_children_summaries = '\n'.join(

--- a/concrete/tools.py
+++ b/concrete/tools.py
@@ -1015,7 +1015,9 @@ class KnowledgeGraphTool(metaclass=MetaTool):
             contents = raw_data.decode('utf-8', errors='replace')
 
         exec = Executive(clients={"openai": OpenAIClient()})
-        child_node_summary = exec.summarize_file(contents=contents, file_name=path, message_format=ChildNodeSummary)
+        child_node_summary = exec.summarize_file(
+            contents=contents, file_name=path, extra_kwargs={'message_format': ChildNodeSummary}
+        )
         repo_node_create = models.RepoNodeUpdate(summary=child_node_summary.summary)
         with Session() as db:
             crud.update_repo_node(db=db, repo_node_id=leaf_node_id, repo_node_update=repo_node_create)
@@ -1042,7 +1044,9 @@ class KnowledgeGraphTool(metaclass=MetaTool):
                     children_summaries.append(f'{child.abs_path}: {child.summary}')
 
         exec = Executive({"openai": OpenAIClient()})
-        node_summary = exec.summarize_from_children(children_summaries, parent_name, message_format=NodeSummary)
+        node_summary = exec.summarize_from_children(
+            children_summaries, parent_name, extra_kwargs={'message_format': NodeSummary}
+        )
         overall_summary = node_summary.overall_summary
         parent_children_summaries = '\n'.join(
             [f'{child_summary.node_name}: {child_summary.summary}' for child_summary in node_summary.children_summaries]

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -48,19 +48,19 @@ class TestOperator(unittest.TestCase):
         class MockOperator(AbstractOperator):
             instructions = "Foo bar baz."
 
-            def method_returning_str(self):
+            def method_returning_str(self, options={}):
                 return "This is a string."
 
-            def method_returning_int(self):
+            def method_returning_int(self, **kwargs):
                 return 42
 
-            def method_returning_none(self):
+            def method_returning_none(self, **kwargs):
                 return None
 
-            def method_returning_list(self):
+            def method_returning_list(self, **kwargs):
                 return [1, 2, 3]
 
-            def method_with_args(self, x=1, y=2):
+            def method_with_args(self, x=1, y=2, options={}):
                 return f"Sum of {x} and {y} is {x + y}"
 
         string_methods = [

--- a/webapp/demo/server.py
+++ b/webapp/demo/server.py
@@ -45,9 +45,10 @@ def _deploy_to_prod(response_url: str):
                 image_uri="008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-homepage:latest",
                 container_name="webapp-homepage",
                 container_port=80,
+                container_env_file=".env",
             ),
         ],
-        "webapp-homepage",
+        service_name="webapp-homepage",
         listener_rule={"field": "host-header", "value": "abop.ai"},
     ) and AwsTool._deploy_service(
         [
@@ -55,6 +56,7 @@ def _deploy_to_prod(response_url: str):
                 image_uri="008971649127.dkr.ecr.us-east-1.amazonaws.com/webapp-demo:latest",
                 container_name="webapp-demo",
                 container_port=80,
+                container_env_file=".env",
             ),
         ],
         listener_rule={"field": "host-header", "value": "demo.abop.ai"},
@@ -216,7 +218,7 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
             so.update(ws=websocket, manager=manager)
             result = ""
             async for operator_type, message in so.process_new_project(
-                starting_prompt=data, deploy=False, use_celery=False
+                starting_prompt=data, deploy=False, run_async=False
             ):
                 result = message
 

--- a/webapp/main/server.py
+++ b/webapp/main/server.py
@@ -444,7 +444,7 @@ async def project_chat_ws(websocket: WebSocket, orchestrator_id: UUID, project_i
             so.add_operator(developer, 'dev')
 
             so.update(ws=websocket, manager=manager)
-            async for operator, response in so.process_new_project(prompt, project.id, use_celery=False):
+            async for operator, response in so.process_new_project(prompt, project.id, run_async=False):
                 CLIClient.emit(f"[{operator}]:\n{response}\n")
                 is_executive = operator == "Executive"
                 await manager.send_text(


### PR DESCRIPTION
- Use `options` to pass in execution options for operator calls
- @MichaelDeng03 please look at the changes I made to `demo/server`. Apparently some mypy errors made it through the cracks for `Container` that I filled just to pass linter.
- Rename `celery` to `run-async` because underlying technology not as important as what it's for.
- Adapted `orchestrator.py` to use new Operator refactor, where `run-async` is passed through to use in Operator.