### PR TITLE
Webapp Dockerfiles Fixes

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -9,7 +9,7 @@ COPY pyproject.toml uv.lock .env ./
 COPY src ./src
 
 COPY webapp/docs ./webapp/docs
-COPY webapp/common.py webapp/__init__.py webapp/pyproject.toml ./webapp/
+COPY webapp/webapp-common ./webapp/webapp-common
 
 WORKDIR /app/webapp/docs
 

--- a/docker/Dockerfile.homepage
+++ b/docker/Dockerfile.homepage
@@ -3,14 +3,14 @@ FROM python:3.11.10-bookworm
 RUN pip install uv==0.4.27
 
 WORKDIR /app
+
 # Common deps
 COPY pyproject.toml uv.lock .env ./
 COPY src ./src
 
 # App specifics
-
 COPY webapp/homepage ./webapp/homepage
-COPY webapp/common.py webapp/__init__.py webapp/pyproject.toml ./webapp/
+COPY webapp/webapp-common ./webapp/webapp-common
 
 WORKDIR /app/webapp/homepage
 RUN uv sync

--- a/docker/Dockerfile.main
+++ b/docker/Dockerfile.main
@@ -10,11 +10,12 @@ COPY src ./src
 
 # App specifics
 COPY webapp/main ./webapp/main
-COPY webapp/common.py webapp/__init__.py webapp/pyproject.toml ./webapp/
+COPY webapp/webapp-common ./webapp/webapp-common
 
 WORKDIR /app/webapp/main
 RUN uv sync
 RUN chmod +x /app/webapp/main/scripts/start.sh
+
 EXPOSE 80
 CMD ["/app/webapp/main/scripts/start.sh"]
 


### PR DESCRIPTION
We've refactored `webapp` to be less of a package and more of a collection of applications.
This meant moving common dependencies into a `webapp-common` package.
This PR is reflecting those changes in the Dockerfiles for `main`, `homepage`, and `docs`.

Update webapp dockerfiles to copy webapp-common