### PR TITLE
Michael/change http to https

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -150,7 +150,8 @@ jobs:
                       --container-env-file .env \
                       --security-groups sg-01af4e696bd2679c3 \
                       --subnets subnet-0644cadc735c6b557 \
-                      --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46"
+                      --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/5f6189397e559d46 \
+                      --http-listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/ConcreteStagingLB/14b30997c81f806e/e084e15f11c52e80"
 
                 if [ -n "$LISTENER_RULE_FIELD" ] && [ -n "$LISTENER_RULE_VALUE" ]; then
                   cmd="$cmd --listener-rule-field \"$LISTENER_RULE_FIELD\" --listener-rule-value \"$LISTENER_RULE_VALUE\""

--- a/src/concrete-core/concrete/__main__.py
+++ b/src/concrete-core/concrete/__main__.py
@@ -102,7 +102,13 @@ deploy_parser.add_argument(
     "--listener-arn",
     type=str,
     required=False,
-    help="Listener ARN of Load Balancer for the service",
+    help="HTTPS Listener ARN of Load Balancer for the service.",
+)
+deploy_parser.add_argument(
+    "--http-listener-arn",
+    type=str,
+    required=False,
+    help="HTTP Listener arn for the service",
 )
 deploy_parser.add_argument(
     "--health-check-path",
@@ -174,7 +180,8 @@ async def main():
                 "subnets": args.subnets,
                 "vpc": args.vpc,
                 "security_groups": args.security_groups,
-                "listener_arn": args.listener_arn,
+                "https_listener_arn": args.listener_arn,
+                "http_listener_arn": args.http_listener_arn,
                 "listener_rule": listener_rule,
                 "health_check_path": args.health_check_path,
             }

--- a/webapp/homepage/scripts/start.sh
+++ b/webapp/homepage/scripts/start.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
 cd /app/webapp/homepage
-uv run --package homepage gunicorn server:app --bind 0.0.0.0:80 --workers 1 --worker-class uvicorn.workers.UvicornWorker --threads 1 --timeout=2000
+uv run gunicorn server:app \
+  --bind 0.0.0.0:80 \
+  --workers 1 \
+  --worker-class uvicorn.workers.UvicornWorker \
+  --threads 1 \
+  --timeout 2000 \
+  --forwarded-allow-ips='*'


### PR DESCRIPTION
- Update AWSTool to allow https and http listener arns.
- Update homepage start script to allow `X-Forwarded-...` headers, preserving client http/https protocol